### PR TITLE
Update repositories to meet (dumb) AWS requirements

### DIFF
--- a/stable/suse-observability-agent/templates/_container-agent.yaml
+++ b/stable/suse-observability-agent/templates/_container-agent.yaml
@@ -1,6 +1,6 @@
 {{- define "container-agent" -}}
 - name: node-agent
-  image: "{{ include "stackstate-k8s-agent.imageRegistry" . }}/{{ .Values.nodeAgent.containers.agent.image.repository }}:{{ .Values.nodeAgent.containers.agent.image.tag }}"
+  image: "{{ .Values.nodeAgent.containers.agent.image.repository }}:{{ .Values.nodeAgent.containers.agent.image.tag }}"
   imagePullPolicy: "{{ .Values.nodeAgent.containers.agent.image.pullPolicy }}"
   env:
     {{ include "stackstate-k8s-agent.apiKeyEnv" . | nindent 4 }}

--- a/stable/suse-observability-agent/templates/_container-process-agent.yaml
+++ b/stable/suse-observability-agent/templates/_container-process-agent.yaml
@@ -1,9 +1,9 @@
 {{- define "container-process-agent" -}}
 - name: process-agent
 {{ if .Values.nodeAgent.containers.processAgent.image.registry }}
-  image: "{{ .Values.nodeAgent.containers.processAgent.image.registry }}/{{ .Values.nodeAgent.containers.processAgent.image.repository }}:{{ .Values.nodeAgent.containers.processAgent.image.tag }}"
+  image: "{{ .Values.nodeAgent.containers.processAgent.image.repository }}:{{ .Values.nodeAgent.containers.processAgent.image.tag }}"
 {{ else }}
-  image: "{{ include "stackstate-k8s-agent.imageRegistry" . }}/{{ .Values.nodeAgent.containers.processAgent.image.repository }}:{{ .Values.nodeAgent.containers.processAgent.image.tag }}"
+  image: "{{ .Values.nodeAgent.containers.processAgent.image.repository }}:{{ .Values.nodeAgent.containers.processAgent.image.tag }}"
 {{- end }}
   imagePullPolicy: "{{ .Values.nodeAgent.containers.processAgent.image.pullPolicy }}"
   ports:

--- a/stable/suse-observability-agent/templates/checks-agent-deployment.yaml
+++ b/stable/suse-observability-agent/templates/checks-agent-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- include "stackstate-k8s-agent.image.pullSecrets" (dict "images" (list .Values.checksAgent.image .Values.all.image) "context" $) | nindent 6 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ include "stackstate-k8s-agent.imageRegistry" . }}/{{ .Values.checksAgent.image.repository }}:{{ .Values.checksAgent.image.tag }}"
+          image: "{{ .Values.checksAgent.image.repository }}:{{ .Values.checksAgent.image.tag }}"
           imagePullPolicy: "{{ .Values.checksAgent.image.pullPolicy }}"
           env:
           {{ include "stackstate-k8s-agent.apiKeyEnv" . | nindent 10 }}

--- a/stable/suse-observability-agent/templates/cluster-agent-deployment.yaml
+++ b/stable/suse-observability-agent/templates/cluster-agent-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: {{ include "stackstate-k8s-agent.fullname" . }}
       containers:
         - name: cluster-agent
-          image: "{{ include "stackstate-k8s-agent.imageRegistry" . }}/{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
+          image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
           imagePullPolicy: "{{ .Values.clusterAgent.image.pullPolicy }}"
           env:
           {{ include "stackstate-k8s-agent.apiKeyEnv" . | nindent 10 }}

--- a/stable/suse-observability-agent/templates/logs-agent-daemonset.yaml
+++ b/stable/suse-observability-agent/templates/logs-agent-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- include "stackstate-k8s-agent.image.pullSecrets" (dict "images" (list .Values.logsAgent.image .Values.all.image) "context" $) | nindent 6 }}
       containers:
         - name: logs-agent
-          image: "{{ include "stackstate-k8s-agent.imageRegistry" . }}/{{ .Values.logsAgent.image.repository }}:{{ .Values.logsAgent.image.tag }}"
+          image: "{{ .Values.logsAgent.image.repository }}:{{ .Values.logsAgent.image.tag }}"
           args:
           - -config.expand-env=true
           - -config.file=/etc/promtail/promtail.yaml

--- a/stable/suse-observability-agent/values.yaml
+++ b/stable/suse-observability-agent/values.yaml
@@ -3,8 +3,6 @@
 #####################
 
 global:
-  # global.imageRegistry -- The image registry to use.
-  imageRegistry: "709825985650.dkr.ecr.us-east-1.amazonaws.com/suse"
   extraEnv:
     # global.extraEnv.open -- Extra open environment variables to inject into pods.
     open: {}
@@ -159,7 +157,7 @@ nodeAgent:
     agent:
       image:
         # nodeAgent.containers.agent.image.repository -- Base container image repository.
-        repository: stackstate/stackstate-k8s-agent
+        repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/stackstate/stackstate-k8s-agent
         # nodeAgent.containers.agent.image.tag -- Default container image tag.
         tag: "8f803adb"
         # nodeAgent.containers.agent.image.pullPolicy -- Default container image pull policy.
@@ -212,10 +210,8 @@ nodeAgent:
       # nodeAgent.containers.processAgent.enabled -- Enable / disable the process agent container.
       enabled: true
       image:
-        # Override to pull the image from an alternate registry
-        registry:
         # nodeAgent.containers.processAgent.image.repository -- Process-agent container image repository.
-        repository: stackstate/stackstate-k8s-process-agent
+        repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/stackstate/stackstate-k8s-process-agent
         # nodeAgent.containers.processAgent.image.tag -- Default process-agent container image tag.
         tag: "e7a68fed"
         # nodeAgent.containers.processAgent.image.pullPolicy -- Process-agent container image pull policy.
@@ -449,7 +445,7 @@ clusterAgent:
 
   image:
     # clusterAgent.image.repository -- Base container image repository.
-    repository: stackstate/stackstate-k8s-cluster-agent
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/stackstate/stackstate-k8s-cluster-agent
     # clusterAgent.image.tag -- Default container image tag.
     tag: "8f803adb"
     # clusterAgent.image.pullPolicy -- Default container image pull policy.
@@ -539,7 +535,7 @@ logsAgent:
 
   image:
     # logsAgent.image.repository -- Base container image repository.
-    repository: stackstate/promtail
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/stackstate/promtail
     # logsAgent.image.tag -- Default container image tag.
     tag: 2.9.15-2a5cc100
     # logsAgent.image.pullPolicy -- Default container image pull policy.
@@ -592,7 +588,7 @@ checksAgent:
 
   image:
     # checksAgent.image.repository -- Base container image repository.
-    repository: stackstate/stackstate-k8s-agent
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/stackstate/stackstate-k8s-agent
     # checksAgent.image.tag -- Default container image tag.
     tag: "8f803adb"
     # checksAgent.image.pullPolicy -- Default container image pull policy.


### PR DESCRIPTION
Global registry is no longer acceptable. See https://docs.aws.amazon.com/marketplace/latest/userguide/container-product-policies.html#helm-chart-structure-requirements